### PR TITLE
chore: stub web/ + web/studio with redirect notice (migrated to bundu-labs/marketing)

### DIFF
--- a/web/MIGRATED.md
+++ b/web/MIGRATED.md
@@ -1,0 +1,47 @@
+# Migrated
+
+The marketing-Mukoko site has moved out of this repo.
+
+## Where it lives now
+
+- **Source code**: https://github.com/bundu-labs/marketing/tree/main/apps/mukoko
+- **Sanity studio**: https://github.com/bundu-labs/marketing/tree/main/studio-mukoko-blog
+- **Stack**: Astro 6 (was Next.js 15) + Tailwind v4, deployed on Vercel.
+- **Sanity project**: `npzanja1`, dataset `production` — reused as-is, no
+  content migration was required.
+
+## Why it moved
+
+The Bundu Family marketing properties (Nyuchi Africa, the Bundu
+Foundation, and Mukoko) now share a single monorepo so they can share
+design tokens, layout primitives (`@bundu-labs/domains`,
+`packages/ui-tokens`), CI checks, and Vercel previews. Keeping Mukoko
+in its own platform repo created drift between the marketing voices.
+
+## What lives in `web/` for now
+
+The original Next.js source tree is intentionally kept on `main` until
+the new Astro site has been live on `mukoko.com` for one release cycle.
+That way we can roll back deploys without resurrecting deleted code.
+
+A follow-up PR will remove `web/` and `web/studio/` once the new site
+has been verified in production.
+
+## How to develop
+
+Don't develop here. Push changes to the marketing repo:
+
+```bash
+gh repo clone bundu-labs/marketing
+cd marketing
+npm install
+npm run dev --workspace=apps/mukoko
+```
+
+The studio is a separate Sanity app:
+
+```bash
+cd studio-mukoko-blog
+npm install
+npm run dev   # http://localhost:3333
+```

--- a/web/studio/MIGRATED.md
+++ b/web/studio/MIGRATED.md
@@ -1,0 +1,26 @@
+# Migrated
+
+The Mukoko Sanity Studio has moved to the marketing monorepo, where it
+sits alongside the studios for the Nyuchi blog and the Bundu newsroom.
+
+## Where it lives now
+
+- **Path**: https://github.com/bundu-labs/marketing/tree/main/studio-mukoko-blog
+- **Sanity project**: `npzanja1`, dataset `production` — unchanged.
+- **Schema**: post / author / category, ported 1:1.
+- **Studio host**: `https://mukoko-blog.sanity.studio` (configured in
+  `sanity.cli.ts`).
+
+No content migration was required — existing posts, authors, and
+categories are read directly by `apps/mukoko/src/lib/sanity.ts` in the
+new monorepo.
+
+## Develop / deploy
+
+```bash
+gh repo clone bundu-labs/marketing
+cd marketing/studio-mukoko-blog
+npm install
+npm run dev      # http://localhost:3333
+npm run deploy   # lifts schema to mukoko-blog.sanity.studio
+```


### PR DESCRIPTION
## Summary

The marketing-Mukoko site (`web/`) and its Sanity studio (`web/studio/`) are being moved to [`bundu-labs/marketing`](https://github.com/bundu-labs/marketing) — the Bundu Family marketing monorepo that already houses Nyuchi Africa, the Bundu Foundation, and (now) Mukoko. The migration PR is [bundu-labs/marketing#14](https://github.com/bundu-labs/marketing/pull/14).

This PR adds two `MIGRATED.md` redirect notices so anyone landing in `web/` or `web/studio/` on this repo learns where the code actually lives now. **The original Next.js source tree and the Sanity studio code stay on `main` for one release cycle** so we can roll back deploys if anything regresses; a follow-up PR will delete `web/` and `web/studio/` once `mukoko.com` has been live on the new Astro site for a release.

## What's in this PR

- `web/MIGRATED.md` — points at `apps/mukoko/` and `studio-mukoko-blog/` in the marketing repo, explains why the move happened and how to develop locally now.
- `web/studio/MIGRATED.md` — same treatment for the Sanity studio. Notes that Sanity project `npzanja1` is reused as-is (no content migration needed).

## What's NOT in this PR

- No deletion of `web/`, `web/studio/`, or any other source. Vercel is still deploying from this repo until the new site cuts over.
- No changes to root config, package.json, or CI.

## Test plan

- [ ] `web/MIGRATED.md` and `web/studio/MIGRATED.md` render correctly on github.com.
- [ ] Existing `web/` build still produces the current marketing site (no behavioural change).
- [ ] Marketing repo PR ([#14](https://github.com/bundu-labs/marketing/pull/14)) lands and the new site is live on `mukoko.com`.
- [ ] Follow-up PR removes the `web/` tree once the new site has been live for one release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKvUoZ1G4HSVvDyN4o9tGn)_